### PR TITLE
Support arbitrary git hosts, not just github.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,33 +6,42 @@ Register a deploy key for a github repository
 [Github Instructions](https://developer.github.com/guides/managing-deploy-keys/#deploy-keys)
 
 ### Step 2
-Create a ```GITHUB_DEPLOY_KEY``` environment variable with the private key that you registered on your Heroku
+Create a ```GIT_DEPLOY_KEY``` environment variable with the private key that you registered on your Heroku
 [Heroku Instructions](https://devcenter.heroku.com/articles/config-vars#setting-up-config-vars-for-a-deployed-application)
 
 I do
 
 ```
-heroku config:set GITHUB_DEPLOY_KEY="`cat /path/to/key`"
+heroku config:set GIT_DEPLOY_KEY="`cat /path/to/key`"
 ```
 
 ### Step 3
-Create a ```GITHUB_HOST_HASH``` environment variable with the identification keys for the hosts that you're going to connect to. These are the keys found in ```~/.ssh/known_hosts```.
+Create a ```GIT_HOST_HASH``` environment variable with the identification keys for the hosts that you're going to connect to. These are the keys found in ```~/.ssh/known_hosts```.
 
 I backed up my ~/.ssh/known_hosts, connected to each host manually via ssh, and then did:
 
 ```
-heroku config:set GITHUB_HOST_HASH="`cat ~/.ssh/known_hosts`"
+heroku config:set GIT_HOST_HASH="`cat ~/.ssh/known_hosts`"
 ```
 
 Afterwards I restored my old known_hosts file.
 
 ### Step 4
+
+Optionally configure `GIT_HOST` and `GIT_USER`. If not provided, they will default to `github.com` and `git` respectively.
+
+```
+heroku config:set GIT_HOST=my-git-host.example.com
+heroku config:set GIT_USER=git-party
+```
+
+### Step 5
 Set your Heroku app's default buildpack to heroku-buildpack-compose
 [Instructions](https://github.com/bwhmather/heroku-buildpack-compose)
 
 You can probably use buildpack-multi, though I haven't tried.
 
-### 5
+### Step 6
 Create a .buildpacks file if you already haven't in the root directory of your app. Make sure it includes this buildpack, and any other buildpacks you need. I'm using Ruby on Rails, so I have:
 
 NOTE: Put this buildpack first!

--- a/bin/compile
+++ b/bin/compile
@@ -4,10 +4,10 @@ require 'fileutils'
 require 'pathname'
 require 'tmpdir'
 
-build_dir    = ARGV[0]
-cache_dir    = ARGV[1]
-env_dir      = ARGV[2]
-ssh_dir      = File.expand_path "#{ENV['HOME']}/.ssh"
+BUILD_DIR    = ARGV[0]
+CACHE_DIR    = ARGV[1]
+ENV_DIR      = ARGV[2]
+SSH_DIR      = File.expand_path "#{ENV['HOME']}/.ssh"
 
 def alert(str)
   str.split('\n').each do |line|
@@ -21,29 +21,59 @@ def arrow(str)
   end
 end
 
+def read_env(env_file)
+  env_file_path = File.join(ENV_DIR, env_file)
+
+  if env_file.include?('GITHUB') && File.exist?(env_file_path)
+    alert "#{env_file} is deprecated, please switch to #{env_file.sub('GITHUB','GIT')}"
+  end
+
+  File.exist?(env_file_path) && File.read(env_file_path) || nil
+end
+
 arrow "############################################"
 arrow "         GIT DEPLOY KEY BUILDPACK           "
 arrow "############################################"
 
-arrow "ssh dir is #{ssh_dir}"
+arrow "ssh dir is #{SSH_DIR}"
 ################# Get the key from heroku's environment config #################
-key_file_path = File.join env_dir, 'GITHUB_DEPLOY_KEY'
-ssh_key = File.open(key_file_path, &:read) if File.exist? key_file_path
+ssh_key = read_env('GIT_DEPLOY_KEY')
+key_file_path = File.join(ENV_DIR, 'GIT_DEPLOY_KEY') if ssh_key
+
+ssh_key ||= read_env('GITHUB_DEPLOY_KEY')
+key_file_path ||= File.join(ENV_DIR, 'GITHUB_DEPLOY_KEY')
 
 if ssh_key.nil?
-  alert "GITHUB_DEDLOY_KEY not set"
-  alert "  Try `heroku config:add GITHUB_DEPLOY_KEY=<your private token>`"
+  alert "GIT_DEPLOY_KEY not set"
+  alert "  Try `heroku config:add GIT_DEPLOY_KEY=<your private token>`"
   exit 1
 end
 
 ############# Get the known host from heroku's environment config ##############
-host_hash_path = File.join env_dir, 'GITHUB_HOST_HASH'
-host_hash = File.open(host_hash_path, &:read) if File.exist? host_hash_path
+host_hash = read_env('GIT_HOST_HASH')
+host_hash ||= read_env('GITHUB_HOST_HASH')
 
 if host_hash.nil?
-  alert "GITHUB_HOST_HASH not set"
-  alert "  Try `heroku config:add GITHUB_HOST_HASH=<hash>`"
+  alert "GIT_HOST_HASH not set"
+  alert "  Try `heroku config:add GIT_HOST_HASH=<hash>`"
   exit 1
+end
+
+
+############# Get the git host from heroku's environment config ################
+git_host = read_env('GIT_HOST')
+
+if git_host.nil?
+  arrow 'GIT_HOST not set, assuming github.com'
+  git_user = 'github.com'
+end
+
+############# Get the git user from heroku's environment config ################
+git_host = read_env('GIT_USER')
+
+if git_host.nil?
+  arrow "GIT_USER not set, assuming 'git'"
+  git_user = 'git'
 end
 
 ###################### Process and clean up the ssh keys #######################
@@ -68,37 +98,37 @@ Dir.mktmpdir 'ssh_buidpack' do |dir|
   # clean_host_hash = `cat "#{dir}/host_hash.pub"`
 
   if temp_key.strip == ''
-    alert "GITHUB_DEPLOY_KEY was invalid"
+    alert "GIT_DEPLOY_KEY was invalid"
     exit 1
   else
-    arrow "Using GITHUB_DEPLOY_KEY #{fingerprint}"
+    arrow "Using GIT_DEPLOY_KEY #{fingerprint}"
   end
 
 end
 
 # Create the ssh directory on the server
-Dir.mkdir(ssh_dir, 0700) unless File.exists?(ssh_dir)
+Dir.mkdir(SSH_DIR, 0700) unless File.exists?(SSH_DIR)
 
 # Create id_rsa file and write contents
-File.open "#{ssh_dir}/id_rsa", 'w' do |f|
+File.open "#{SSH_DIR}/id_rsa", 'w' do |f|
   f.write ssh_key
 end
-FileUtils.chmod 0600, "#{ssh_dir}/id_rsa"
+FileUtils.chmod 0600, "#{SSH_DIR}/id_rsa"
 arrow "Wrote ssh key to user's ssh dir"
 
 #create known_hosts file and write contents
-File.open "#{ssh_dir}/known_hosts", 'w' do |f|
+File.open "#{SSH_DIR}/known_hosts", 'w' do |f|
   f.write host_hash
 end
-FileUtils.chmod 0600, "#{ssh_dir}/known_hosts"
+FileUtils.chmod 0600, "#{SSH_DIR}/known_hosts"
 arrow "Wrote host hash to user's known hosts"
 
-File.open "#{ssh_dir}/config", 'w' do |f|
-  f.puts "IdentityFile #{ssh_dir}/id_rsa"
-  f.puts "host github.com"
-  f.puts "     user git"
-  f.puts "     IdentityFile #{ssh_dir}/id_rsa"
+File.open "#{SSH_DIR}/config", 'w' do |f|
+  f.puts "IdentityFile #{SSH_DIR}/id_rsa"
+  f.puts "host #{git_host}"
+  f.puts "     user #{git_user}"
+  f.puts "     IdentityFile #{SSH_DIR}/id_rsa"
 end
-FileUtils.chmod 0600, "#{ssh_dir}/config"
+FileUtils.chmod 0600, "#{SSH_DIR}/config"
 arrow "Wrote config to user's config"
 


### PR DESCRIPTION
Removes GITHUB from ENV names, adds `GIT_HOST` and `GIT_USER`. Should be backwards-compatible with `GITHUB_*` env variables, but give a warning to upgrade.
